### PR TITLE
Install gatsby-plugin-netlify-cache

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -10,11 +10,11 @@ module.exports = {
     url: 'http:/',
   },
   plugins: [
-    'gatsby-plugin-react-helmet',
+    `gatsby-plugin-react-helmet`,
     `gatsby-plugin-styled-components`,
     `gatsby-plugin-stripe-checkout`,
     `gatsby-plugin-stripe-elements`,
-    'gatsby-plugin-layout',
+    `gatsby-plugin-layout`,
     {
       resolve: `gatsby-plugin-manifest`,
       options: {
@@ -27,7 +27,7 @@ module.exports = {
         icon: `src/images/favicon.ico`, // This path is relative to the root of the site.
       },
     },
-    'gatsby-plugin-offline',
+    `gatsby-plugin-offline`,
     {
       resolve: `gatsby-plugin-google-analytics`,
       options: {
@@ -46,7 +46,7 @@ module.exports = {
       },
     },
     {
-      resolve: 'gatsby-source-shopify',
+      resolve: `gatsby-source-shopify`,
       options: {
         shopName: 'lipslut2-0',
         accessToken: '68c81bce2d7868af2bf51cb7fd99066a',
@@ -54,5 +54,6 @@ module.exports = {
       },
     },
     `gatsby-plugin-netlify`,
+    `gatsby-plugin-netlify-cache`,
   ],
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10005,6 +10005,27 @@
         }
       }
     },
+    "gatsby-plugin-netlify-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-netlify-cache/-/gatsby-plugin-netlify-cache-1.0.0.tgz",
+      "integrity": "sha512-lNdFUrtuEfee2FaR9Eh9ZF2gUvHQEbjZa9cNUltHj045r4Ej3dI9sXearx/+3IMbwS84aE4Q2yGEu/woNUPa+g==",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "fs-extra": "^7.0.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        }
+      }
+    },
     "gatsby-plugin-offline": {
       "version": "2.0.15",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-offline/-/gatsby-plugin-offline-2.0.15.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "gatsby-plugin-mailchimp": "^4.0.0",
     "gatsby-plugin-manifest": "^2.0.9",
     "gatsby-plugin-netlify": "^2.0.5",
+    "gatsby-plugin-netlify-cache": "^1.0.0",
     "gatsby-plugin-offline": "^2.0.15",
     "gatsby-plugin-react-helmet": "^3.0.2",
     "gatsby-plugin-stripe-checkout": "^1.0.7",


### PR DESCRIPTION
1. In order to speed up build times on Netlify, installed Gatsby plugin (gatsby-plugin-netlify-cache) to cache build files in the Netlify cache directory.

NOTE: [the folder is undocumented](https://www.contentful.com/blog/2018/05/17/faster-static-site-builds-part-one-process-only-what-you-need/#caching-for-the-win).